### PR TITLE
Mac os adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,18 @@ This 3 entries must be added at the end of each list.
 
 #### MAC
 
-TODO
+1. First it is necessary to [disable SIP](https://developer.apple.com/library/mac/documentation/Security/Conceptual/System_Integrity_Protection_Guide/ConfiguringSystemIntegrityProtection/ConfiguringSystemIntegrityProtection.html) That doesn't allow the editing of files in /usr/.
+
+2. You have to have to add the NanoS to /usr/libexec/SmartCardServices/drivers/ifd-ccid.bundle/Contents/Info.plist
+
+
+       In  <key>ifdVendorID</key>      add the entry  <string>0x2C97</string>
+       In  <key>ifdProductID</key>     add the entry  <string>0x0001</string>
+       In  <key>ifdFriendlyName</key>  add the entry  <string>Ledger Token</string>
+  
+This 3 entries must be added at the end of each list.
+
+3. [Enable SIP](https://developer.apple.com/library/content/documentation/Security/Conceptual/System_Integrity_Protection_Guide/ConfiguringSystemIntegrityProtection/ConfiguringSystemIntegrityProtection.html)
 
 #### Windows
 


### PR DESCRIPTION
Mac Os 10.11 protects the files with a set up called SIP that must be disabled 
to be able to modify the .plist file.
Also provided the path for the file in 10.2 MAC OSX systems.
Still the "keytocard" operation doesn't work but the card is visible with
gpg2 --card-status and is editable with gpg2 --card-edit command.